### PR TITLE
Rewrite parser

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,5 +14,4 @@ pub enum RodoCommands {
     Catalog { opt_filepath: Option<String> },
     /// List all the TODOs in a given folder. The default value is the current directory.
     List { opt_filepath: Option<String> },
-    
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,13 +1,14 @@
 extern crate walkdir;
-use walkdir::{DirEntry, WalkDir};
 use std::fs::File;
-use std::io::{ self, Read};
+use std::io::{self, Read};
 use std::str;
+use walkdir::{DirEntry, WalkDir};
 
-use super::parser::{Todo, parse_file};
+use super::parser::{parse_file, Todo};
 
 fn is_hidden(entry: &DirEntry) -> bool {
-    entry.file_name()
+    entry
+        .file_name()
         .to_str()
         .map(|s| s.starts_with('.'))
         .unwrap_or(false)
@@ -20,20 +21,19 @@ pub fn list_path_todos(directory_path: &str) -> Vec<Todo> {
     for file_path in WalkDir::new(directory_path)
         .into_iter()
         .filter_entry(|e| !is_hidden(e))
-        .filter_map(|file| file.ok()) {
+        .filter_map(|file| file.ok())
+    {
+        let file = File::open(file_path.path()).unwrap();
+        let mut file_buffer = io::BufReader::new(file);
+        let mut content_buffer = String::new();
 
-	          let file = File::open(file_path.path()).unwrap();
-	          let mut file_buffer = io::BufReader::new(file);
-	          let mut content_buffer = String::new();
+        // file doesn't contain valid string (binary file): skip
+        file_buffer.read_to_string(&mut content_buffer).ok();
 
-            // file doesn't contain valid string (binary file): skip
-            file_buffer
-                .read_to_string(&mut content_buffer).ok();
+        // look for todos in file
+        let mut file_todos = parse_file(content_buffer.as_str());
 
-            // look for todos in file
-            let mut file_todos = parse_file(content_buffer.as_str());
-
-            todos.append(&mut file_todos)
-        }
+        todos.append(&mut file_todos)
+    }
     todos
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -7,41 +7,41 @@ use std::str;
 
 fn is_hidden(entry: &DirEntry) -> bool {
     entry.file_name()
-         .to_str()
-         .map(|s| s.starts_with('.'))
-         .unwrap_or(false)
+        .to_str()
+        .map(|s| s.starts_with('.'))
+        .unwrap_or(false)
 }
 
 pub fn list_path(directory_path: &str) -> Result<Vec<String>, ()> {
-  let mut todos = Vec::new();
-  for file_path in WalkDir::new(directory_path).into_iter().filter_entry(|e| !is_hidden(e)).filter_map(|file| file.ok()) {
-      if file_path.metadata().unwrap().is_file() {
-	  let file = File::open(file_path.path()).unwrap();
-	  let mut file_buffer = io::BufReader::new(file);
-	  let mut content_buffer = String::new();
-	  loop {
-	      match file_buffer.read_line(&mut content_buffer) {
-		  Ok(0) => break,
-		  Ok(_) => {
-		      content_buffer.pop(); // This is to remove the new line at the end
-		      match parser::todo()(content_buffer.as_str().as_bytes()) {
-			  Ok(x) => {
-			      match str::from_utf8(x.1) {
-				  Ok(v) => {				      
-				      todos.push(v.to_string());
-				  },
-				  Err(_e) => (),
-			      };
-			  },
-			  Err(_e) => ()
-		      }
-		      content_buffer.clear();
-		  },
-		 Err(_) => ()
-	      }
-	  }
-	  // println!("Parsed TODOs from file {:?}", file_path.path().display());
-      }
-  }
-  Ok(todos)
+    let mut todos = Vec::new();
+    for file_path in WalkDir::new(directory_path).into_iter().filter_entry(|e| !is_hidden(e)).filter_map(|file| file.ok()) {
+        if file_path.metadata().unwrap().is_file() {
+	          let file = File::open(file_path.path()).unwrap();
+	          let mut file_buffer = io::BufReader::new(file);
+	          let mut content_buffer = String::new();
+	          loop {
+	              match file_buffer.read_line(&mut content_buffer) {
+		                Ok(0) => break,
+		                Ok(_) => {
+		                    content_buffer.pop(); // This is to remove the new line at the end
+		                    match parser::todo()(content_buffer.as_str().as_bytes()) {
+			                      Ok(x) => {
+			                          match str::from_utf8(x.1) {
+				                            Ok(v) => {
+				                                todos.push(v.to_string());
+				                            },
+				                            Err(_e) => (),
+			                          };
+			                      },
+			                      Err(_e) => ()
+		                    }
+		                    content_buffer.clear();
+		                },
+		                Err(_) => ()
+	              }
+	          }
+	          // println!("Parsed TODOs from file {:?}", file_path.path().display());
+        }
+    }
+    Ok(todos)
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -35,5 +35,5 @@ pub fn list_path_todos(directory_path: &str) -> Vec<Todo> {
 
             todos.append(&mut file_todos)
         }
-    return todos
+    todos
 }

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -192,28 +192,3 @@ fn todo_different_tag() {
     let input = "FIXME: different tag";
     assert_eq!(parse_todo("TODO:", input).ok(), None);
 }
-
-// pub fn parse_todo1<'a>(todo_tag: &'a str, input: &'a str) -> IResult<&'a str, &'a str> {
-//     preceded(take_until(todo_tag), rest)(input)
-// }
-
-// #[test]
-// fn todo_clean1() {
-//     let input = "TODO: test todo";
-//     assert_eq!(parse_todo1("TODO:", input), Ok(("", "TODO: test todo")));
-// }
-
-// #[test]
-// fn todo_in_comment1() {
-//     let input = "// TODO: test todo";
-//     assert_eq!(parse_todo1("TODO:", input), Ok(("", "TODO: test todo")));
-// }
-
-// #[test]
-// fn todo_different_tag1() {
-//     let input = "FIXME: different tag";
-//     match parse_todo1("TODO:", input) {
-//         Ok(_) => assert!(false),
-//         Err(_) => assert!(true),
-//     }
-// }

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -12,7 +12,6 @@ pub struct Todo {
     pub text: String,
 }
 
-
 fn parse_todo<'a>(todo_tag: &'a str, input: &'a str) -> IResult<&'a str, Todo> {
     // remove everything prior to the tag
     let (input, _) = take_until(todo_tag)(input)?;
@@ -42,150 +41,156 @@ pub fn parse_file(file_content: &str) -> Vec<Todo> {
     }
 }
 
-#[test]
-fn todos() {
-    let input =
-        "line 1\n\
-         TODO: todo1\n\
-         line 2\n\
-         line 3 -- TODO: todo2\n";
 
-    assert_eq!(parse_todos(input),
-               Ok(("",
-                   vec![
-                       Todo{ tag: "TODO:".to_owned(),
-                             text: " todo1".to_owned()},
-                       Todo{ tag: "TODO:".to_owned(),
-                             text: " todo2".to_owned()},
-                   ])
-               )
-    );
+#[cfg(test)]
+mod test {
+    use crate::commands::parser::{parse_todos, Todo, parse_todo};
 
-    let input = "line 1\n";
-    assert_eq!(parse_todos(input),
-               Ok(("line 1\n",
-                   vec![])
-               )
-    );
+    #[test]
+    fn todos() {
+        let input =
+            "line 1\n\
+             TODO: todo1\n\
+             line 2\n\
+             line 3 -- TODO: todo2\n";
 
-    let input = "line1 TODO: todo1\n";
-    assert_eq!(parse_todos(input),
-               Ok(("",
-                   vec![
-                       Todo { tag: "TODO:".to_owned(),
-                              text: " todo1".to_owned()}])
-               )
-    );
+        assert_eq!(parse_todos(input),
+                   Ok(("",
+                       vec![
+                           Todo{ tag: "TODO:".to_owned(),
+                                 text: " todo1".to_owned()},
+                           Todo{ tag: "TODO:".to_owned(),
+                                 text: " todo2".to_owned()},
+                       ])
+                   )
+        );
 
-    let input =
-        "line1\n\
-         line2\n\
-         line3\n\
-         TODO: todo1\n\
-         line4\n";
-    assert_eq!(parse_todos(input),
-               Ok(("line4\n",
-                   vec![
-                       Todo { tag: "TODO:".to_owned(),
-                              text: " todo1".to_owned()}])
-               )
-    );
+        let input = "line 1\n";
+        assert_eq!(parse_todos(input),
+                   Ok(("line 1\n",
+                       vec![])
+                   )
+        );
 
-    let input =
-        "line1\n\
-         line2\n\
-         line3\n\
-         FIXME: todo1\n\
-         line4\n";
-    assert_eq!(parse_todos(input),
-               Ok((input,
-                   vec![])
-               )
-    );
+        let input = "line1 TODO: todo1\n";
+        assert_eq!(parse_todos(input),
+                   Ok(("",
+                       vec![
+                           Todo { tag: "TODO:".to_owned(),
+                                  text: " todo1".to_owned()}])
+                   )
+        );
 
-}
+        let input =
+            "line1\n\
+             line2\n\
+             line3\n\
+             TODO: todo1\n\
+             line4\n";
+        assert_eq!(parse_todos(input),
+                   Ok(("line4\n",
+                       vec![
+                           Todo { tag: "TODO:".to_owned(),
+                                  text: " todo1".to_owned()}])
+                   )
+        );
+
+        let input =
+            "line1\n\
+             line2\n\
+             line3\n\
+             FIXME: todo1\n\
+             line4\n";
+        assert_eq!(parse_todos(input),
+                   Ok((input,
+                       vec![])
+                   )
+        );
+
+    }
 
 
-#[test]
-fn todo_clean() {
-    let input = "TODO: test todo";
-    assert_eq!(
-        parse_todo("TODO:", input),
-        Ok(("",
-            Todo {
-                tag: "TODO:".to_owned(),
-                text: " test todo".to_owned()
-            })
-        )
-    );
-}
+    #[test]
+    fn todo_clean() {
+        let input = "TODO: test todo";
+        assert_eq!(
+            parse_todo("TODO:", input),
+            Ok(("",
+                Todo {
+                    tag: "TODO:".to_owned(),
+                    text: " test todo".to_owned()
+                })
+            )
+        );
+    }
 
-#[test]
-fn todo_tag_only() {
-    let input = "TODO:\nline1";
-    assert_eq!(
-        parse_todo("TODO:", input),
-        Ok(("line1",
-            Todo {
-                tag: "TODO:".to_owned(),
-                text: "".to_owned()
-            })
-        )
-    );
+    #[test]
+    fn todo_tag_only() {
+        let input = "TODO:\nline1";
+        assert_eq!(
+            parse_todo("TODO:", input),
+            Ok(("line1",
+                Todo {
+                    tag: "TODO:".to_owned(),
+                    text: "".to_owned()
+                })
+            )
+        );
 
-    let input = "TODO:";
-    assert_eq!(
-        parse_todo("TODO:", input),
-        Ok(("",
-            Todo {
-                tag: "TODO:".to_owned(),
-                text: "".to_owned()
-            })
-        )
-    );
+        let input = "TODO:";
+        assert_eq!(
+            parse_todo("TODO:", input),
+            Ok(("",
+                Todo {
+                    tag: "TODO:".to_owned(),
+                    text: "".to_owned()
+                })
+            )
+        );
 
-    let input = "TODO:\n";
-    assert_eq!(
-        parse_todo("TODO:", input),
-        Ok(("",
-            Todo {
-                tag: "TODO:".to_owned(),
-                text: "".to_owned()
-            })
-        )
-    );
-}
+        let input = "TODO:\n";
+        assert_eq!(
+            parse_todo("TODO:", input),
+            Ok(("",
+                Todo {
+                    tag: "TODO:".to_owned(),
+                    text: "".to_owned()
+                })
+            )
+        );
+    }
 
-#[test]
-fn todo_clean_newline() {
-    let input = "TODO: test todo\nline1";
-    assert_eq!(
-        parse_todo("TODO:", input),
-        Ok(("line1",
-            Todo {
-                tag: "TODO:".to_owned(),
-                text: " test todo".to_owned()
-            })
-        )
-    );
-}
+    #[test]
+    fn todo_clean_newline() {
+        let input = "TODO: test todo\nline1";
+        assert_eq!(
+            parse_todo("TODO:", input),
+            Ok(("line1",
+                Todo {
+                    tag: "TODO:".to_owned(),
+                    text: " test todo".to_owned()
+                })
+            )
+        );
+    }
 
-#[test]
-fn todo_in_comment() {
-    let input = "// TODO: test todo";
-    assert_eq!(
-        parse_todo("TODO:", input),
-        Ok(("",
-            Todo {
-                tag: "TODO:".to_owned(),
-                text: " test todo".to_owned()
-            })
-        )
-    );
-}
+    #[test]
+    fn todo_in_comment() {
+        let input = "// TODO: test todo";
+        assert_eq!(
+            parse_todo("TODO:", input),
+            Ok(("",
+                Todo {
+                    tag: "TODO:".to_owned(),
+                    text: " test todo".to_owned()
+                })
+            )
+        );
+    }
 
-#[test]
-fn todo_different_tag() {
-    let input = "FIXME: different tag";
-    assert_eq!(parse_todo("TODO:", input).ok(), None);
+    #[test]
+    fn todo_different_tag() {
+        let input = "FIXME: different tag";
+        assert_eq!(parse_todo("TODO:", input).ok(), None);
+    }
 }

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -1,73 +1,219 @@
-use nom::{*, bytes::complete::{take_until, take_till}, character::{is_newline}, error::*, sequence::*};
+use nom::{
+    bytes::complete::{take_till, take_until, tag},
+    character::{is_newline, complete::{newline, not_line_ending}},
+    error::*,
+    sequence::preceded,
+    combinator::opt,
+    multi::many0,
+    *,
+};
 
 pub fn todo() -> impl Fn(&[u8]) -> IResult<&[u8], &[u8], Error<&[u8]>> {
     move |i: &[u8]| {
-	let header = take_until("TODO:");
-	let content = take_till(is_newline);
-	preceded(header, content)(i)
+        let header = take_until("TODO:");
+        let content = take_till(is_newline);
+        preceded(header, content)(i)
     }
 }
 
 #[derive(Debug, PartialEq)]
-pub enum PResult<'a> {
-    Todo {
-        text: &'a str
-    },
-    NoTodo
+pub struct Todo<'a> {
+    tag: &'a str,
+    text: &'a str,
 }
 
-pub fn parse_todo<'a>(todo_tag: &'a str, input: &'a str) -> PResult<'a> {
-    preceded(
-        take_until(todo_tag),
-        rest::<&str, ()>
-    )(input).map_or(PResult::NoTodo,
-                    |(_, result)| PResult::Todo {text: result} )
+pub fn parse_todo<'a>(todo_tag: &'a str, input: &'a str) -> IResult<&'a str, Todo<'a>> {
+    // remove everything prior to the tag
+    let (input, _) = take_until(todo_tag)(input)?;
+
+    let (input, _) = tag(todo_tag)(input)?;
+    let (input, text) = not_line_ending(input)?;
+
+    // discard optional line ending
+    let (input, _) = opt(newline)(input)?;
+
+    Ok((input, Todo {
+        tag: todo_tag,
+        text
+    }))
 }
+
+pub fn parse_todos<'a>(file_content: &'a str) -> IResult<&'a str, Vec<Todo<'a>>> {
+    let line_parser = | file_content | parse_todo("TODO:", file_content);
+    let (input, todos) = many0(line_parser)(file_content)?;
+    Ok((input, todos))
+}
+
+
+#[test]
+fn todos() {
+    let input =
+        "line 1\n\
+         TODO: todo1\n\
+         line 2\n\
+         line 3 -- TODO: todo2\n";
+
+    assert_eq!(parse_todos(input),
+               Ok(("",
+                   vec![
+                       Todo{ tag: "TODO:",
+                             text: " todo1"},
+                       Todo{ tag: "TODO:",
+                             text: " todo2"},
+                   ])
+               )
+    );
+
+    let input = "line 1\n";
+    assert_eq!(parse_todos(input),
+               Ok(("line 1\n",
+                   vec![])
+               )
+    );
+
+    let input = "line1 TODO: todo1\n";
+    assert_eq!(parse_todos(input),
+               Ok(("",
+                   vec![
+                       Todo { tag: "TODO:",
+                              text: " todo1"}])
+               )
+    );
+
+    let input =
+        "line1\n\
+         line2\n\
+         line3\n\
+         TODO: todo1\n\
+         line4\n";
+    assert_eq!(parse_todos(input),
+               Ok(("line4\n",
+                   vec![
+                       Todo { tag: "TODO:",
+                              text: " todo1"}])
+               )
+    );
+
+    let input =
+        "line1\n\
+         line2\n\
+         line3\n\
+         FIXME: todo1\n\
+         line4\n";
+    assert_eq!(parse_todos(input),
+               Ok((input,
+                   vec![])
+               )
+    );
+
+}
+
 
 #[test]
 fn todo_clean() {
     let input = "TODO: test todo";
-    assert_eq!(parse_todo("TODO:", input), PResult::Todo{text: "TODO: test todo"});
+    assert_eq!(
+        parse_todo("TODO:", input),
+        Ok(("",
+            Todo {
+                tag: "TODO:",
+                text: " test todo"
+            })
+        )
+    );
+}
+
+#[test]
+fn todo_tag_only() {
+    let input = "TODO:\nline1";
+    assert_eq!(
+        parse_todo("TODO:", input),
+        Ok(("line1",
+            Todo {
+                tag: "TODO:",
+                text: ""
+            })
+        )
+    );
+
+    let input = "TODO:";
+    assert_eq!(
+        parse_todo("TODO:", input),
+        Ok(("",
+            Todo {
+                tag: "TODO:",
+                text: ""
+            })
+        )
+    );
+
+    let input = "TODO:\n";
+    assert_eq!(
+        parse_todo("TODO:", input),
+        Ok(("",
+            Todo {
+                tag: "TODO:",
+                text: ""
+            })
+        )
+    );
+}
+
+#[test]
+fn todo_clean_newline() {
+    let input = "TODO: test todo\nline1";
+    assert_eq!(
+        parse_todo("TODO:", input),
+        Ok(("line1",
+            Todo {
+                tag: "TODO:",
+                text: " test todo"
+            })
+        )
+    );
 }
 
 #[test]
 fn todo_in_comment() {
     let input = "// TODO: test todo";
-    assert_eq!(parse_todo("TODO:", input), PResult::Todo{text: "TODO: test todo"});
+    assert_eq!(
+        parse_todo("TODO:", input),
+        Ok(("",
+            Todo {
+                tag: "TODO:",
+                text: " test todo"
+            })
+        )
+    );
 }
 
 #[test]
 fn todo_different_tag() {
     let input = "FIXME: different tag";
-    assert_eq!(parse_todo("TODO:", input), PResult::NoTodo);
+    assert_eq!(parse_todo("TODO:", input).ok(), None);
 }
 
+// pub fn parse_todo1<'a>(todo_tag: &'a str, input: &'a str) -> IResult<&'a str, &'a str> {
+//     preceded(take_until(todo_tag), rest)(input)
+// }
 
+// #[test]
+// fn todo_clean1() {
+//     let input = "TODO: test todo";
+//     assert_eq!(parse_todo1("TODO:", input), Ok(("", "TODO: test todo")));
+// }
 
-pub fn parse_todo1<'a>(todo_tag: &'a str, input: &'a str) -> IResult<&'a str, &'a str> {
-    preceded(
-        take_until(todo_tag),
-        rest
-    )(input)
-}
+// #[test]
+// fn todo_in_comment1() {
+//     let input = "// TODO: test todo";
+//     assert_eq!(parse_todo1("TODO:", input), Ok(("", "TODO: test todo")));
+// }
 
-#[test]
-fn todo_clean1() {
-    let input = "TODO: test todo";
-    assert_eq!(parse_todo1("TODO:", input), Ok(("", "TODO: test todo")));
-}
-
-#[test]
-fn todo_in_comment1() {
-    let input = "// TODO: test todo";
-    assert_eq!(parse_todo1("TODO:", input), Ok(("", "TODO: test todo")));
-}
-
-#[test]
-fn todo_different_tag1() {
-    let input = "FIXME: different tag";
-    match parse_todo1("TODO:", input) {
-        Ok(_) => assert!(false),
-        Err(_) => assert!(true)
-    }
-}
+// #[test]
+// fn todo_different_tag1() {
+//     let input = "FIXME: different tag";
+//     match parse_todo1("TODO:", input) {
+//         Ok(_) => assert!(false),
+//         Err(_) => assert!(true),
+//     }
+// }

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -1,6 +1,6 @@
 use nom::{
     bytes::complete::{take_until, tag},
-    character::{complete::{newline, not_line_ending}},
+    character::complete::{newline, not_line_ending},
     combinator::opt,
     multi::many0,
     *,
@@ -28,7 +28,7 @@ fn parse_todo<'a>(todo_tag: &'a str, input: &'a str) -> IResult<&'a str, Todo> {
     }))
 }
 
-fn parse_todos<'a>(file_content: &'a str) -> IResult<&'a str, Vec<Todo>> {
+fn parse_todos(file_content: &str) -> IResult<&str, Vec<Todo>> {
     let line_parser = | file_content | parse_todo("TODO:", file_content);
     let (input, todos) = many0(line_parser)(file_content)?;
     Ok((input, todos))

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -6,6 +6,9 @@ use nom::{
     *,
 };
 
+// TODO: change String to &str in the Todo type \
+// Making this will break the list_todos_path() function because of ownership of
+// the file contents.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Todo {
     pub tag: String,

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -14,15 +14,14 @@ pub fn todo() -> impl Fn(&[u8]) -> IResult<&[u8], &[u8], Error<&[u8]>> {
         let content = take_till(is_newline);
         preceded(header, content)(i)
     }
+#[derive(Debug, PartialEq, Clone)]
+pub struct Todo {
+    pub tag: String,
+    pub text: String,
 }
 
-#[derive(Debug, PartialEq)]
-pub struct Todo<'a> {
-    tag: &'a str,
-    text: &'a str,
-}
 
-pub fn parse_todo<'a>(todo_tag: &'a str, input: &'a str) -> IResult<&'a str, Todo<'a>> {
+fn parse_todo<'a>(todo_tag: &'a str, input: &'a str) -> IResult<&'a str, Todo> {
     // remove everything prior to the tag
     let (input, _) = take_until(todo_tag)(input)?;
 
@@ -33,12 +32,12 @@ pub fn parse_todo<'a>(todo_tag: &'a str, input: &'a str) -> IResult<&'a str, Tod
     let (input, _) = opt(newline)(input)?;
 
     Ok((input, Todo {
-        tag: todo_tag,
-        text
+        tag: todo_tag.to_owned(),
+        text: text.to_owned(),
     }))
 }
 
-pub fn parse_todos<'a>(file_content: &'a str) -> IResult<&'a str, Vec<Todo<'a>>> {
+fn parse_todos<'a>(file_content: &'a str) -> IResult<&'a str, Vec<Todo>> {
     let line_parser = | file_content | parse_todo("TODO:", file_content);
     let (input, todos) = many0(line_parser)(file_content)?;
     Ok((input, todos))
@@ -56,10 +55,10 @@ fn todos() {
     assert_eq!(parse_todos(input),
                Ok(("",
                    vec![
-                       Todo{ tag: "TODO:",
-                             text: " todo1"},
-                       Todo{ tag: "TODO:",
-                             text: " todo2"},
+                       Todo{ tag: "TODO:".to_owned(),
+                             text: " todo1".to_owned()},
+                       Todo{ tag: "TODO:".to_owned(),
+                             text: " todo2".to_owned()},
                    ])
                )
     );
@@ -75,8 +74,8 @@ fn todos() {
     assert_eq!(parse_todos(input),
                Ok(("",
                    vec![
-                       Todo { tag: "TODO:",
-                              text: " todo1"}])
+                       Todo { tag: "TODO:".to_owned(),
+                              text: " todo1".to_owned()}])
                )
     );
 
@@ -89,8 +88,8 @@ fn todos() {
     assert_eq!(parse_todos(input),
                Ok(("line4\n",
                    vec![
-                       Todo { tag: "TODO:",
-                              text: " todo1"}])
+                       Todo { tag: "TODO:".to_owned(),
+                              text: " todo1".to_owned()}])
                )
     );
 
@@ -116,8 +115,8 @@ fn todo_clean() {
         parse_todo("TODO:", input),
         Ok(("",
             Todo {
-                tag: "TODO:",
-                text: " test todo"
+                tag: "TODO:".to_owned(),
+                text: " test todo".to_owned()
             })
         )
     );
@@ -130,8 +129,8 @@ fn todo_tag_only() {
         parse_todo("TODO:", input),
         Ok(("line1",
             Todo {
-                tag: "TODO:",
-                text: ""
+                tag: "TODO:".to_owned(),
+                text: "".to_owned()
             })
         )
     );
@@ -141,8 +140,8 @@ fn todo_tag_only() {
         parse_todo("TODO:", input),
         Ok(("",
             Todo {
-                tag: "TODO:",
-                text: ""
+                tag: "TODO:".to_owned(),
+                text: "".to_owned()
             })
         )
     );
@@ -152,8 +151,8 @@ fn todo_tag_only() {
         parse_todo("TODO:", input),
         Ok(("",
             Todo {
-                tag: "TODO:",
-                text: ""
+                tag: "TODO:".to_owned(),
+                text: "".to_owned()
             })
         )
     );
@@ -166,8 +165,8 @@ fn todo_clean_newline() {
         parse_todo("TODO:", input),
         Ok(("line1",
             Todo {
-                tag: "TODO:",
-                text: " test todo"
+                tag: "TODO:".to_owned(),
+                text: " test todo".to_owned()
             })
         )
     );
@@ -180,8 +179,8 @@ fn todo_in_comment() {
         parse_todo("TODO:", input),
         Ok(("",
             Todo {
-                tag: "TODO:",
-                text: " test todo"
+                tag: "TODO:".to_owned(),
+                text: " test todo".to_owned()
             })
         )
     );

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -1,5 +1,5 @@
 use nom::{
-    bytes::complete::{take_until, tag},
+    bytes::complete::{tag, take_until},
     character::complete::{newline, not_line_ending},
     combinator::opt,
     multi::many0,
@@ -22,14 +22,17 @@ fn parse_todo<'a>(todo_tag: &'a str, input: &'a str) -> IResult<&'a str, Todo> {
     // discard optional line ending
     let (input, _) = opt(newline)(input)?;
 
-    Ok((input, Todo {
-        tag: todo_tag.to_owned(),
-        text: text.to_owned(),
-    }))
+    Ok((
+        input,
+        Todo {
+            tag: todo_tag.to_owned(),
+            text: text.to_owned(),
+        },
+    ))
 }
 
 fn parse_todos(file_content: &str) -> IResult<&str, Vec<Todo>> {
-    let line_parser = | file_content | parse_todo("TODO:", file_content);
+    let line_parser = |file_content| parse_todo("TODO:", file_content);
     let (input, todos) = many0(line_parser)(file_content)?;
     Ok((input, todos))
 }
@@ -41,86 +44,85 @@ pub fn parse_file(file_content: &str) -> Vec<Todo> {
     }
 }
 
-
 #[cfg(test)]
 mod test {
-    use crate::commands::parser::{parse_todos, Todo, parse_todo};
+    use crate::commands::parser::{parse_todo, parse_todos, Todo};
 
     #[test]
     fn todos() {
-        let input =
-            "line 1\n\
+        let input = "line 1\n\
              TODO: todo1\n\
              line 2\n\
              line 3 -- TODO: todo2\n";
 
-        assert_eq!(parse_todos(input),
-                   Ok(("",
-                       vec![
-                           Todo{ tag: "TODO:".to_owned(),
-                                 text: " todo1".to_owned()},
-                           Todo{ tag: "TODO:".to_owned(),
-                                 text: " todo2".to_owned()},
-                       ])
-                   )
+        assert_eq!(
+            parse_todos(input),
+            Ok((
+                "",
+                vec![
+                    Todo {
+                        tag: "TODO:".to_owned(),
+                        text: " todo1".to_owned()
+                    },
+                    Todo {
+                        tag: "TODO:".to_owned(),
+                        text: " todo2".to_owned()
+                    },
+                ]
+            ))
         );
 
         let input = "line 1\n";
-        assert_eq!(parse_todos(input),
-                   Ok(("line 1\n",
-                       vec![])
-                   )
-        );
+        assert_eq!(parse_todos(input), Ok(("line 1\n", vec![])));
 
         let input = "line1 TODO: todo1\n";
-        assert_eq!(parse_todos(input),
-                   Ok(("",
-                       vec![
-                           Todo { tag: "TODO:".to_owned(),
-                                  text: " todo1".to_owned()}])
-                   )
+        assert_eq!(
+            parse_todos(input),
+            Ok((
+                "",
+                vec![Todo {
+                    tag: "TODO:".to_owned(),
+                    text: " todo1".to_owned()
+                }]
+            ))
         );
 
-        let input =
-            "line1\n\
+        let input = "line1\n\
              line2\n\
              line3\n\
              TODO: todo1\n\
              line4\n";
-        assert_eq!(parse_todos(input),
-                   Ok(("line4\n",
-                       vec![
-                           Todo { tag: "TODO:".to_owned(),
-                                  text: " todo1".to_owned()}])
-                   )
+        assert_eq!(
+            parse_todos(input),
+            Ok((
+                "line4\n",
+                vec![Todo {
+                    tag: "TODO:".to_owned(),
+                    text: " todo1".to_owned()
+                }]
+            ))
         );
 
-        let input =
-            "line1\n\
+        let input = "line1\n\
              line2\n\
              line3\n\
              FIXME: todo1\n\
              line4\n";
-        assert_eq!(parse_todos(input),
-                   Ok((input,
-                       vec![])
-                   )
-        );
-
+        assert_eq!(parse_todos(input), Ok((input, vec![])));
     }
-
 
     #[test]
     fn todo_clean() {
         let input = "TODO: test todo";
         assert_eq!(
             parse_todo("TODO:", input),
-            Ok(("",
+            Ok((
+                "",
                 Todo {
                     tag: "TODO:".to_owned(),
                     text: " test todo".to_owned()
-                })
-            )
+                }
+            ))
         );
     }
 
@@ -129,34 +131,37 @@ mod test {
         let input = "TODO:\nline1";
         assert_eq!(
             parse_todo("TODO:", input),
-            Ok(("line1",
+            Ok((
+                "line1",
                 Todo {
                     tag: "TODO:".to_owned(),
                     text: "".to_owned()
-                })
-            )
+                }
+            ))
         );
 
         let input = "TODO:";
         assert_eq!(
             parse_todo("TODO:", input),
-            Ok(("",
+            Ok((
+                "",
                 Todo {
                     tag: "TODO:".to_owned(),
                     text: "".to_owned()
-                })
-            )
+                }
+            ))
         );
 
         let input = "TODO:\n";
         assert_eq!(
             parse_todo("TODO:", input),
-            Ok(("",
+            Ok((
+                "",
                 Todo {
                     tag: "TODO:".to_owned(),
                     text: "".to_owned()
-                })
-            )
+                }
+            ))
         );
     }
 
@@ -165,12 +170,13 @@ mod test {
         let input = "TODO: test todo\nline1";
         assert_eq!(
             parse_todo("TODO:", input),
-            Ok(("line1",
+            Ok((
+                "line1",
                 Todo {
                     tag: "TODO:".to_owned(),
                     text: " test todo".to_owned()
-                })
-            )
+                }
+            ))
         );
     }
 
@@ -179,12 +185,13 @@ mod test {
         let input = "// TODO: test todo";
         assert_eq!(
             parse_todo("TODO:", input),
-            Ok(("",
+            Ok((
+                "",
                 Todo {
                     tag: "TODO:".to_owned(),
                     text: " test todo".to_owned()
-                })
-            )
+                }
+            ))
         );
     }
 

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -7,3 +7,67 @@ pub fn todo() -> impl Fn(&[u8]) -> IResult<&[u8], &[u8], Error<&[u8]>> {
 	preceded(header, content)(i)
     }
 }
+
+#[derive(Debug, PartialEq)]
+pub enum PResult<'a> {
+    Todo {
+        text: &'a str
+    },
+    NoTodo
+}
+
+pub fn parse_todo<'a>(todo_tag: &'a str, input: &'a str) -> PResult<'a> {
+    preceded(
+        take_until(todo_tag),
+        rest::<&str, ()>
+    )(input).map_or(PResult::NoTodo,
+                    |(_, result)| PResult::Todo {text: result} )
+}
+
+#[test]
+fn todo_clean() {
+    let input = "TODO: test todo";
+    assert_eq!(parse_todo("TODO:", input), PResult::Todo{text: "TODO: test todo"});
+}
+
+#[test]
+fn todo_in_comment() {
+    let input = "// TODO: test todo";
+    assert_eq!(parse_todo("TODO:", input), PResult::Todo{text: "TODO: test todo"});
+}
+
+#[test]
+fn todo_different_tag() {
+    let input = "FIXME: different tag";
+    assert_eq!(parse_todo("TODO:", input), PResult::NoTodo);
+}
+
+
+
+pub fn parse_todo1<'a>(todo_tag: &'a str, input: &'a str) -> IResult<&'a str, &'a str> {
+    preceded(
+        take_until(todo_tag),
+        rest
+    )(input)
+}
+
+#[test]
+fn todo_clean1() {
+    let input = "TODO: test todo";
+    assert_eq!(parse_todo1("TODO:", input), Ok(("", "TODO: test todo")));
+}
+
+#[test]
+fn todo_in_comment1() {
+    let input = "// TODO: test todo";
+    assert_eq!(parse_todo1("TODO:", input), Ok(("", "TODO: test todo")));
+}
+
+#[test]
+fn todo_different_tag1() {
+    let input = "FIXME: different tag";
+    match parse_todo1("TODO:", input) {
+        Ok(_) => assert!(false),
+        Err(_) => assert!(true)
+    }
+}

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -43,6 +43,12 @@ fn parse_todos<'a>(file_content: &'a str) -> IResult<&'a str, Vec<Todo>> {
     Ok((input, todos))
 }
 
+pub fn parse_file(file_content: &str) -> Vec<Todo> {
+    match parse_todos(file_content) {
+        Ok((_, todos)) => todos,
+        Err(_) => vec![],
+    }
+}
 
 #[test]
 fn todos() {

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -1,19 +1,11 @@
 use nom::{
-    bytes::complete::{take_till, take_until, tag},
-    character::{is_newline, complete::{newline, not_line_ending}},
-    error::*,
-    sequence::preceded,
+    bytes::complete::{take_until, tag},
+    character::{complete::{newline, not_line_ending}},
     combinator::opt,
     multi::many0,
     *,
 };
 
-pub fn todo() -> impl Fn(&[u8]) -> IResult<&[u8], &[u8], Error<&[u8]>> {
-    move |i: &[u8]| {
-        let header = take_until("TODO:");
-        let content = take_till(is_newline);
-        preceded(header, content)(i)
-    }
 #[derive(Debug, PartialEq, Clone)]
 pub struct Todo {
     pub tag: String,

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,16 +1,18 @@
 use colored::Colorize;
 
-fn display_todo(msg: &mut String) {
-    msg.replace_range(..5, "");
-    let body = msg.trim();
-    println!(
+use crate::commands::parser::Todo;
+
+impl Todo {
+    pub fn display(todo: Todo) -> String {
+    format!(
         "{} {}",
-        "TODO:".bold().blue().underline(),
-	body)
+        todo.tag.bold().blue().underline(),
+	      todo.text)
+    }
 }
 
-pub fn display_todos(msgs: Vec<String>) {
-    for mut msg in msgs {
-	display_todo(&mut msg);
+pub fn display_todos(todos: Vec<Todo>) {
+    for todo in todos {
+	      println!("{}", Todo::display(todo));
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -4,15 +4,12 @@ use crate::commands::parser::Todo;
 
 impl Todo {
     pub fn display(todo: Todo) -> String {
-    format!(
-        "{} {}",
-        todo.tag.bold().blue().underline(),
-	      todo.text)
+        format!("{} {}", todo.tag.bold().blue().underline(), todo.text)
     }
 }
 
 pub fn display_todos(todos: Vec<Todo>) {
     for todo in todos {
-	      println!("{}", Todo::display(todo));
+        println!("{}", Todo::display(todo));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod cli;
+use clap::Parser;
 use cli::Cli;
 use cli::RodoCommands;
-use clap::{Parser};
 mod commands;
 use commands::catalog;
 use commands::list;
@@ -15,13 +15,13 @@ fn main() {
     let current_dir_str = current_dir.into_os_string().into_string().unwrap();
     match &cli.command {
         RodoCommands::Catalog { opt_filepath } => {
-	          let filepath = opt_filepath.to_owned().unwrap_or(current_dir_str);
-	          let _todos = catalog::catalog_path(filepath.as_str()).unwrap();
-        },
-	      RodoCommands::List { opt_filepath } => {
-	          let filepath = opt_filepath.to_owned().unwrap_or(current_dir_str);
-	          let todos = list::list_path_todos(filepath.as_str());
-	          display_todos(todos)
+            let filepath = opt_filepath.to_owned().unwrap_or(current_dir_str);
+            let _todos = catalog::catalog_path(filepath.as_str()).unwrap();
+        }
+        RodoCommands::List { opt_filepath } => {
+            let filepath = opt_filepath.to_owned().unwrap_or(current_dir_str);
+            let todos = list::list_path_todos(filepath.as_str());
+            display_todos(todos)
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,13 +15,13 @@ fn main() {
     let current_dir_str = current_dir.into_os_string().into_string().unwrap();
     match &cli.command {
         RodoCommands::Catalog { opt_filepath } => {
-	    let filepath = opt_filepath.to_owned().unwrap_or(current_dir_str);
-	    let _todos = catalog::catalog_path(filepath.as_str()).unwrap();
+	          let filepath = opt_filepath.to_owned().unwrap_or(current_dir_str);
+	          let _todos = catalog::catalog_path(filepath.as_str()).unwrap();
         },
-	RodoCommands::List { opt_filepath } => {
-	    let filepath = opt_filepath.to_owned().unwrap_or(current_dir_str);
-	    let todos = list::list_path(filepath.as_str()).unwrap();
-	    display_todos(todos)
+	      RodoCommands::List { opt_filepath } => {
+	          let filepath = opt_filepath.to_owned().unwrap_or(current_dir_str);
+	          let todos = list::list_path_todos(filepath.as_str());
+	          display_todos(todos)
         }
     }
 }


### PR DESCRIPTION
The TODO parser should treat its own errors instead of exposing them to the caller. 

The TODO parser can either
1. Succeed, in which case it should report the text it found for later processing;
2. Fail, in which case there's no TODO to report.

Most importantly, we are dealing with `&str` instead of `&[u8]` directly. 